### PR TITLE
feat(perspt): add meta-package for unified crate access

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ members = [
     "crates/perspt-sandbox",
     "crates/perspt-cli",
     "crates/perspt-store",
+    "crates/perspt",
 ]
 
 [workspace.package]
@@ -18,3 +19,13 @@ authors = ["Vikrant Rathore", "Ronak Rathore"]
 license = "LGPL-3.0"
 repository = "https://github.com/eonseed/perspt"
 homepage = "https://eonseed.github.io/perspt/"
+
+[workspace.dependencies]
+perspt-core = { version = "0.5.2", path = "crates/perspt-core" }
+perspt-agent = { version = "0.5.2", path = "crates/perspt-agent" }
+perspt-tui = { version = "0.5.2", path = "crates/perspt-tui" }
+perspt-policy = { version = "0.5.2", path = "crates/perspt-policy" }
+perspt-sandbox = { version = "0.5.2", path = "crates/perspt-sandbox" }
+perspt-store = { version = "0.5.2", path = "crates/perspt-store" }
+perspt-cli = { version = "0.5.2", path = "crates/perspt-cli" }
+perspt = { version = "0.5.2", path = "crates/perspt" }

--- a/crates/perspt/Cargo.toml
+++ b/crates/perspt/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "perspt"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+readme = "../../README.md"
+documentation = "https://docs.rs/perspt"
+description = "Your Terminal's Window to the AI World - A high-performance CLI for LLMs with chat and autonomous agent modes"
+keywords = ["llm", "ai", "terminal", "chat", "agent"]
+categories = ["command-line-utilities", "development-tools"]
+
+[dependencies]
+perspt-core = { workspace = true }
+perspt-agent = { workspace = true }
+perspt-store = { workspace = true }
+perspt-policy = { workspace = true }
+perspt-sandbox = { workspace = true }

--- a/crates/perspt/src/lib.rs
+++ b/crates/perspt/src/lib.rs
@@ -1,0 +1,13 @@
+//! # Perspt: Your Terminal's Window to the AI World
+//!
+//! A high-performance command-line interface (CLI) application that gives you a peek
+//! into the mind of Large Language Models (LLMs). Built with Rust for speed and reliability,
+//! it allows you to chat with various AI models from multiple providers directly in your terminal.
+//!
+//! This crate is a meta-package that re-exports the core libraries of the Perspt workspace.
+
+pub use perspt_agent as agent;
+pub use perspt_core as core;
+pub use perspt_policy as policy;
+pub use perspt_sandbox as sandbox;
+pub use perspt_store as store;


### PR DESCRIPTION
## Pull Request Type
- [x] **General** - Standard code changes, bug fixes, features, documentation
- [ ] **PSP** - Perspt Specification Proposal (new PSP document or PSP updates)

---

## Description
This PR creates a new \`perspt\` crate that acts as a meta-package, re-exporting all the core libraries of the Perspt workspace. This allows users to depend on a single \`perspt\` crate to access all functionality.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Code cleanup/refactoring
- [ ] PSP document (new or updated Perspt Specification Proposal)

## Related Issues
Fixes #76

---

## General Testing & Validation
- [x] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing completed
- [ ] PSP builds successfully with Sphinx (PSP PRs only)
- [ ] No formatting errors or warnings (PSP PRs only)

### Test Configuration
- **OS**: macOS
- **Rust Version**: stable

## Implementation Details
- Created \`crates/perspt\` with \`Cargo.toml\` and \`src/lib.rs\`
- Added \`workspace.dependencies\` to root \`Cargo.toml\` for version consistency
- Re-exports: \`perspt-core\`, \`perspt-agent\`, \`perspt-store\`, \`perspt-policy\`, \`perspt-sandbox\`
- \`readme = "../../README.md"\` ensures crates.io displays the root README
- Description matches the project tagline: *Your Terminal's Window to the AI World*

## Final Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code/document
- [x] I have commented my code, particularly in hard-to-understand areas (General PRs)
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works (General PRs)
- [x] New and existing unit tests pass locally with my changes (General PRs)
- [ ] Any dependent changes have been merged and published

## Additional Notes
This meta-package simplifies the user experience by providing a single entry point for all Perspt libraries. Users can now \`use perspt::core\`, \`perspt::agent\`, etc., instead of depending on individual crates.