### PR TITLE
feat: implement diff-based file editing with stability checks

### DIFF
--- a/crates/perspt-agent/Cargo.toml
+++ b/crates/perspt-agent/Cargo.toml
@@ -45,6 +45,7 @@ log = "0.4"
 grep = "0.4"
 ignore = "0.4"
 regex = "1.12.2"
+diffy = "0.4"
 
 [dev-dependencies]
 tempfile = "3.14"

--- a/crates/perspt-agent/src/agent.rs
+++ b/crates/perspt-agent/src/agent.rs
@@ -160,21 +160,38 @@ Target Output File: {target_file}
 7. Add type annotations if missing
 8. Import any missing modules
 
-## Output Format
-You MUST output the code in this EXACT format:
+6. Output Format:
+   - For NEW files: Use 'File: {target_file}' followed by the full code.
+   - For EXISTING files: Use 'Diff: {target_file}' followed by a Unified Diff.
 
+## Output Format Examples
+
+### Creating a New File
 File: {target_file}
 ```python
-# Your complete implementation here
-# Include ALL necessary imports
-# Include the COMPLETE file, not just snippets
+import os
+
+def main():
+    print("Hello")
+```
+
+### Modifying an Existing File
+Diff: {target_file}
+```diff
+--- {target_file}
++++ {target_file}
+@@ -10,2 +10,3 @@
+ def calculate(x):
+-    return x * 2
++    return x * 3
++    # Fixed calculation
 ```
 
 IMPORTANT:
-- The "File:" line MUST appear before the code block
-- Provide the COMPLETE corrected file, not just snippets
-- Include all imports at the top
-- Do not skip any functions or classes"#,
+- Use 'Diff:' for existing files to save tokens and apply changes safely.
+- Use 'File:' ONLY for new files or when rewriting the entire file is simpler.
+- For Diffs, include the standard header (---/+++) and @@ lines.
+- Do NOT output the full file contents if you are only changing a few lines."#,
             goal = node.goal,
             interface = contract.interface_signature,
             invariants = contract.invariants,

--- a/crates/perspt-agent/src/orchestrator.rs
+++ b/crates/perspt-agent/src/orchestrator.rs
@@ -65,6 +65,8 @@ pub struct SRBNOrchestrator {
     action_receiver: Option<perspt_core::events::channel::ActionReceiver>,
     /// Persistence ledger
     pub ledger: crate::ledger::MerkleLedger,
+    /// Last tool failure message (for energy calculation)
+    pub last_tool_failure: Option<String>,
 }
 
 impl SRBNOrchestrator {
@@ -129,6 +131,7 @@ impl SRBNOrchestrator {
             event_sender: None,
             action_receiver: None,
             ledger: crate::ledger::MerkleLedger::new().expect("Failed to create ledger"),
+            last_tool_failure: None,
         }
     }
 
@@ -1141,21 +1144,24 @@ IMPORTANT: Output ONLY the JSON, no other text."#,
             }
         }
         // Then check for file code blocks (for TaskType::Code)
-        else if let Some(code_info) = self.extract_code_from_response(content) {
-            log::info!("Extracted code for file: {}", code_info.0);
-            self.emit_log(format!("📝 File proposed: {}", code_info.0));
+        else if let Some((filename, code, is_diff)) = self.extract_code_from_response(content) {
+            log::info!("Extracted code for file: {} (diff={})", filename, is_diff);
+            self.emit_log(format!(
+                "📝 File proposed: {} (diff: {})",
+                filename, is_diff
+            ));
 
             // Build full path
-            let full_path = self.context.working_dir.join(&code_info.0);
+            let full_path = self.context.working_dir.join(&filename);
 
             // Request approval before writing file
             let approval_result = self
                 .await_approval(
                     perspt_core::ActionType::FileWrite {
-                        path: code_info.0.clone(),
+                        path: filename.clone(),
                     },
-                    format!("Write file: {}", code_info.0),
-                    Some(code_info.1.clone()),
+                    format!("Write file: {}", filename),
+                    Some(code.clone()),
                 )
                 .await;
 
@@ -1167,20 +1173,28 @@ IMPORTANT: Output ONLY the JSON, no other text."#,
                 return Ok(());
             }
 
-            // Create a tool call to write the file
             let mut args = HashMap::new();
-            args.insert("path".to_string(), code_info.0.clone());
-            args.insert("content".to_string(), code_info.1.clone());
+            args.insert("path".to_string(), filename.clone());
 
-            let call = ToolCall {
-                name: "apply_patch".to_string(),
-                arguments: args,
+            let call = if is_diff {
+                args.insert("diff".to_string(), code.clone());
+                ToolCall {
+                    name: "apply_diff".to_string(),
+                    arguments: args,
+                }
+            } else {
+                args.insert("content".to_string(), code.clone());
+                ToolCall {
+                    name: "write_file".to_string(), // Previously alias for apply_patch (fs::write)
+                    arguments: args,
+                }
             };
 
             let result = self.tools.execute(&call).await;
             if result.success {
-                log::info!("✓ Wrote file: {}", code_info.0);
-                self.emit_log(format!("✅ Wrote file: {}", code_info.0));
+                log::info!("✓ Applied changes to: {}", filename);
+                self.emit_log(format!("✅ Applied changes to: {}", filename));
+                self.last_tool_failure = None; // Reset error
 
                 // Track the written file for LSP verification
                 self.last_written_file = Some(full_path.clone());
@@ -1189,16 +1203,36 @@ IMPORTANT: Output ONLY the JSON, no other text."#,
                 // Notify LSP of file change (if LSP is running)
                 if let Some(client) = self.lsp_clients.get_mut("python") {
                     if self.file_version == 1 {
-                        let _ = client.did_open(&full_path, &code_info.1).await;
+                        let _ = client.did_open(&full_path, &code).await; // Note: For diff, we should ideally send full text but we don't have it easily here without reading back.
+                                                                          // Ideally we should reread file from disk for LSP sync if it was a diff
+                        if is_diff {
+                            if let Ok(new_content) = std::fs::read_to_string(&full_path) {
+                                let _ = client
+                                    .did_change(&full_path, &new_content, self.file_version)
+                                    .await;
+                            }
+                        } else {
+                            let _ = client.did_open(&full_path, &code).await;
+                        }
                     } else {
-                        let _ = client
-                            .did_change(&full_path, &code_info.1, self.file_version)
-                            .await;
+                        // For diff, read back file
+                        if is_diff {
+                            if let Ok(new_content) = std::fs::read_to_string(&full_path) {
+                                let _ = client
+                                    .did_change(&full_path, &new_content, self.file_version)
+                                    .await;
+                            }
+                        } else {
+                            let _ = client
+                                .did_change(&full_path, &code, self.file_version)
+                                .await;
+                        }
                     }
                 }
             } else {
-                log::warn!("Failed to write file: {:?}", result.error);
-                self.emit_log(format!("❌ Failed to write file: {:?}", result.error));
+                log::warn!("Failed to apply changes: {:?}", result.error);
+                self.emit_log(format!("❌ Failed: {:?}", result.error));
+                self.last_tool_failure = result.error.clone();
             }
         } else {
             log::debug!(
@@ -1236,7 +1270,9 @@ IMPORTANT: Output ONLY the JSON, no other text."#,
 
     /// Extract code from LLM response
     /// Returns (filename, code_content) if found
-    fn extract_code_from_response(&self, content: &str) -> Option<(String, String)> {
+    /// Extract code from LLM response
+    /// Returns (filename, code_content, is_diff) if found
+    fn extract_code_from_response(&self, content: &str) -> Option<(String, String, bool)> {
         // Look for patterns like:
         // File: hello_world.py
         // ```python
@@ -1266,6 +1302,21 @@ IMPORTANT: Output ONLY the JSON, no other text."#,
                 }
             }
 
+            // Look for Diff patterns
+            if line.starts_with("Diff:") || line.starts_with("**Diff:") || line.starts_with("diff:")
+            {
+                let path = line
+                    .trim_start_matches("Diff:")
+                    .trim_start_matches("**Diff:")
+                    .trim_start_matches("diff:")
+                    .trim_start_matches("**")
+                    .trim_end_matches("**")
+                    .trim();
+                if !path.is_empty() {
+                    file_path = Some(path.to_string());
+                }
+            }
+
             // Parse code blocks
             if line.starts_with("```") && !in_code_block {
                 in_code_block = true;
@@ -1284,17 +1335,16 @@ IMPORTANT: Output ONLY the JSON, no other text."#,
                         .unwrap_or_else(|| match code_lang.as_str() {
                             "python" | "py" => "main.py".to_string(),
                             "rust" | "rs" => "main.rs".to_string(),
-                            "javascript" | "js" => "main.js".to_string(),
-                            "typescript" | "ts" => "main.ts".to_string(),
-                            _ => {
-                                if let Some(dir) = self.ledger.artifacts_dir() {
-                                    dir.join("output.txt").to_string_lossy().to_string()
-                                } else {
-                                    "output.txt".to_string()
-                                }
-                            }
+                            _ => "output.txt".to_string(),
                         });
-                    return Some((filename, code));
+                    // Check if it's a diff
+                    let is_diff = code_lang == "diff"
+                        || code.starts_with("---")
+                        || file_path
+                            .as_ref()
+                            .map(|_| content.contains("Diff:"))
+                            .unwrap_or(false);
+                    return Some((filename, code, is_diff));
                 }
                 continue;
             }
@@ -1317,6 +1367,27 @@ IMPORTANT: Output ONLY the JSON, no other text."#,
 
         // Calculate energy components
         let mut energy = EnergyComponents::default();
+
+        // V_syn: From Tool Failures (Critical)
+        if let Some(ref err) = self.last_tool_failure {
+            energy.v_syn = 10.0; // High energy for tool failure
+            log::warn!("Tool failure detected, V_syn set to 10.0: {}", err);
+            self.emit_log(format!("⚠️ Tool failure prevents verification: {}", err));
+            // We can return early or allow other checks. Usually tool failure means broken state.
+
+            // Store diagnostics mock for correction prompt
+            self.context.last_diagnostics = vec![lsp_types::Diagnostic {
+                range: lsp_types::Range::default(),
+                severity: Some(lsp_types::DiagnosticSeverity::ERROR),
+                code: None,
+                code_description: None,
+                source: Some("tool".to_string()),
+                message: format!("Failed to apply changes: {}", err),
+                related_information: None,
+                tags: None,
+                data: None,
+            }];
+        }
 
         // V_syn: From LSP diagnostics
         if let Some(ref path) = self.last_written_file {
@@ -1516,23 +1587,32 @@ IMPORTANT: Output ONLY the JSON, no other text."#,
         let corrected = self.call_llm_for_correction(&correction_prompt).await?;
 
         // Extract and apply diff
-        if let Some((filename, new_code)) = self.extract_code_from_response(&corrected) {
+        if let Some((filename, new_code, is_diff)) = self.extract_code_from_response(&corrected) {
             let full_path = self.context.working_dir.join(&filename);
 
             // Write corrected file
             let mut args = HashMap::new();
             args.insert("path".to_string(), filename.clone());
-            args.insert("content".to_string(), new_code.clone());
 
-            let call = ToolCall {
-                name: "apply_patch".to_string(),
-                arguments: args,
+            let call = if is_diff {
+                args.insert("diff".to_string(), new_code.clone());
+                ToolCall {
+                    name: "apply_diff".to_string(),
+                    arguments: args,
+                }
+            } else {
+                args.insert("content".to_string(), new_code.clone());
+                ToolCall {
+                    name: "write_file".to_string(),
+                    arguments: args,
+                }
             };
 
             let result = self.tools.execute(&call).await;
             if result.success {
                 log::info!("✓ Applied correction to: {}", filename);
                 self.emit_log(format!("📝 Applied correction to: {}", filename));
+                self.last_tool_failure = None;
 
                 // Update tracking
                 self.last_written_file = Some(full_path.clone());
@@ -1540,10 +1620,14 @@ IMPORTANT: Output ONLY the JSON, no other text."#,
 
                 // Notify LSP of file change
                 if let Some(client) = self.lsp_clients.get_mut("python") {
-                    let _ = client
-                        .did_change(&full_path, &new_code, self.file_version)
-                        .await;
+                    if let Ok(content) = std::fs::read_to_string(&full_path) {
+                        let _ = client
+                            .did_change(&full_path, &content, self.file_version)
+                            .await;
+                    }
                 }
+            } else {
+                self.last_tool_failure = result.error;
             }
         }
 

--- a/crates/perspt-agent/src/tools.rs
+++ b/crates/perspt-agent/src/tools.rs
@@ -3,6 +3,7 @@
 //! Tools available to agents for interacting with the workspace.
 //! Implements: read_file, search_code, apply_patch, run_command
 
+use diffy::{apply, Patch};
 use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -80,6 +81,7 @@ impl AgentTools {
             "run_command" => self.run_command(call).await,
             "list_files" => self.list_files(call),
             "write_file" => self.write_file(call),
+            "apply_diff" => self.apply_diff(call),
             // Power Tools (OS-level)
             "sed_replace" => self.sed_replace(call),
             "awk_filter" => self.awk_filter(call),
@@ -168,6 +170,58 @@ impl AgentTools {
             Err(e) => {
                 ToolResult::failure("apply_patch", format!("Failed to write {:?}: {}", path, e))
             }
+        }
+    }
+
+    /// Apply a unified diff patch to a file
+    fn apply_diff(&self, call: &ToolCall) -> ToolResult {
+        let path = match call.arguments.get("path") {
+            Some(p) => self.resolve_path(p),
+            None => {
+                return ToolResult::failure("apply_diff", "Missing 'path' argument".to_string())
+            }
+        };
+
+        let diff_content = match call.arguments.get("diff") {
+            Some(c) => c,
+            None => {
+                return ToolResult::failure("apply_diff", "Missing 'diff' argument".to_string())
+            }
+        };
+
+        // Read original file
+        let original = match fs::read_to_string(&path) {
+            Ok(c) => c,
+            Err(e) => {
+                // If file doesn't exist, we can't patch it.
+                // (Unless it's a new file creation patch, but diffy usually assumes base text)
+                return ToolResult::failure(
+                    "apply_diff",
+                    format!("Failed to read base file {:?}: {}", path, e),
+                );
+            }
+        };
+
+        // Parse patch
+        let patch = match Patch::from_str(diff_content) {
+            Ok(p) => p,
+            Err(e) => {
+                return ToolResult::failure("apply_diff", format!("Failed to parse diff: {}", e));
+            }
+        };
+
+        // Apply patch
+        match apply(&original, &patch) {
+            Ok(patched) => match fs::write(&path, patched) {
+                Ok(_) => {
+                    ToolResult::success("apply_diff", format!("Successfully patched {:?}", path))
+                }
+                Err(e) => ToolResult::failure(
+                    "apply_diff",
+                    format!("Failed to write patched file: {}", e),
+                ),
+            },
+            Err(e) => ToolResult::failure("apply_diff", format!("Failed to apply patch: {}", e)),
         }
     }
 
@@ -462,6 +516,22 @@ pub fn get_tool_definitions() -> Vec<ToolDefinition> {
             ],
         },
         ToolDefinition {
+            name: "apply_diff".to_string(),
+            description: "Apply a Unified Diff patch to a file".to_string(),
+            parameters: vec![
+                ToolParameter {
+                    name: "path".to_string(),
+                    description: "Path to the file to patch".to_string(),
+                    required: true,
+                },
+                ToolParameter {
+                    name: "diff".to_string(),
+                    description: "Unified Diff content".to_string(),
+                    required: true,
+                },
+            ],
+        },
+        ToolDefinition {
             name: "run_command".to_string(),
             description: "Execute a shell command in the working directory".to_string(),
             parameters: vec![ToolParameter {
@@ -587,5 +657,40 @@ mod tests {
 
         let result = tools.execute(&call).await;
         assert!(result.success);
+    }
+
+    #[tokio::test]
+    async fn test_apply_diff_tool() {
+        use std::collections::HashMap;
+        use std::io::Write;
+        let temp_dir = temp_dir();
+        let file_path = temp_dir.join("test_diff.txt");
+        let mut file = std::fs::File::create(&file_path).unwrap();
+        // Explicitly write bytes with unix newlines
+        file.write_all(b"Hello world\nThis is a test\n").unwrap();
+
+        let tools = AgentTools::new(temp_dir.clone(), true);
+
+        // Exact string with newlines
+        let diff = "--- test_diff.txt\n+++ test_diff.txt\n@@ -1,2 +1,2 @@\n-Hello world\n+Hello diffy\n This is a test\n";
+
+        let mut args = HashMap::new();
+        args.insert("path".to_string(), "test_diff.txt".to_string());
+        args.insert("diff".to_string(), diff.to_string());
+
+        let call = ToolCall {
+            name: "apply_diff".to_string(),
+            arguments: args,
+        };
+
+        let result = tools.apply_diff(&call);
+        assert!(
+            result.success,
+            "Diff application failed: {:?}",
+            result.error
+        );
+
+        let content = fs::read_to_string(&file_path).unwrap();
+        assert_eq!(content, "Hello diffy\nThis is a test\n");
     }
 }


### PR DESCRIPTION
## Pull Request Type
- [x] **General** - Standard code changes, bug fixes, features, documentation
- [ ] **PSP** - Perspt Specification Proposal (new PSP document or PSP updates)

---

## Description
Implemented diff-based file editing using the \`diffy\` crate. This replaces the full-file overwrite method in the \`ActuatorAgent\` and \`SRBNOrchestrator\`, allowing for more granular and token-efficient file modifications. It also introduces stability checks where failed diff applications result in high \`V_syn\` energy, triggering corrective actions.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [x] Code cleanup/refactoring
- [ ] PSP document (new or updated Perspt Specification Proposal)

## Related Issues
Fixes #78

---

## PSP Information
<!-- ✅ FILL OUT ONLY IF YOU SELECTED "PSP" ABOVE -->
<!-- ❌ SKIP THIS SECTION FOR GENERAL PULL REQUESTS -->

---

## General Testing & Validation
- [x] Unit tests pass
- [ ] Integration tests pass
- [x] Manual testing completed

### Test Configuration
- **OS**: macOS
- **Rust Version**: 1.75.0+

## Implementation Details
- Integrated \`diffy\` crate for unified diff parsing and application.
- Added \`apply_diff\` tool to \`AgentTools\`.
- Updated \`extract_code_from_response\` in \`SRBNOrchestrator\` to handle \`Diff:\` blocks.
- Modified \`step_speculate\` and \`step_converge\` to utilize the new patching mechanism.
- Implemented energy penalty logic for tool failures in \`step_verify\`.

## Additional Information

### Screenshots (if applicable)

## Final Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code/document
- [x] I have commented my code, particularly in hard-to-understand areas (General PRs)
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works (General PRs)
- [x] New and existing unit tests pass locally with my changes (General PRs)
- [x] Any dependent changes have been merged and published